### PR TITLE
Use ceylon-gradle-plugin (fixes #2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@ Ceylon language support for Android
 
 This plugin adds support for writing Android applications using the [Ceylon language](http://ceylon-lang.org).
 
-This plugin is based on the excellent Groovy Android plugin at https://github.com/groovy/groovy-android-gradle-plugin.
+This plugin is based on the excellent [Groovy Android plugin](https://github.com/groovy/groovy-android-gradle-plugin)
+and on [ceylon-gradle-plugin](https://github.com/renatoathaydes/ceylon-gradle-plugin).
 
 Usage
 -----
@@ -21,11 +22,14 @@ buildscript {
     }
 }
 
+apply plugin: 'com.android.application'
+apply plugin: 'com.athaydes.ceylon'
 apply plugin: 'com.redhat.ceylon.gradle.android'
 
-androidCeylon {
-    ceylonExecutable "/usr/bin/ceylon"
-    mainModule "com.my.module/1.0"
+ceylon {
+    // Optional, needs to point to Ceylon 1.2.3+
+    // ceylonLocation "/usr/bin/ceylon"
+    module "com.my.module/1.0"
 }
 ```
 

--- a/android/android.gradle
+++ b/android/android.gradle
@@ -34,7 +34,7 @@ dependencies {
   compile gradleApi()
 
   compile "com.android.tools.build:gradle:$androidPluginVersion"
-//  compile "com.athaydes.gradle.ceylon:ceylon-gradle-plugin:1.1"
+  compile "com.athaydes.gradle.ceylon:ceylon-gradle-plugin:1.1.2"
 
   testCompile gradleTestKit()
   testCompile 'org.spockframework:spock-core:1.0-groovy-2.4', {

--- a/android/src/main/groovy/com/redhat/ceylon/gradle/android/CeylonAndroidExtension.groovy
+++ b/android/src/main/groovy/com/redhat/ceylon/gradle/android/CeylonAndroidExtension.groovy
@@ -43,16 +43,6 @@ class CeylonAndroidExtension {
    */
   boolean skipJavaC
 
-  /**
-   * Absolute path to the ceylon executable.
-   */
-  def ceylonExecutable = "/usr/bin/ceylon"
-
-  /**
-   * Name and version of the main Ceylon module.
-   */
-  def mainModule = "default/1.0"
-
   final NamedDomainObjectContainer<AndroidCeylonSourceSet> sourceSetsContainer
 
   private Closure<Void> configClosure

--- a/android/src/main/groovy/com/redhat/ceylon/gradle/android/CeylonAndroidPlugin.groovy
+++ b/android/src/main/groovy/com/redhat/ceylon/gradle/android/CeylonAndroidPlugin.groovy
@@ -62,6 +62,11 @@ class CeylonAndroidPlugin implements Plugin<Project> {
         throw new GradleException('You must apply the Android plugin or the Android library plugin before using the ceylon-android plugin')
     }
 
+    def ceylonPlugin = getCeylonPlugin(project)
+    if (!ceylonPlugin) {
+      throw new GradleException('You must apply the com.athaydes.ceylon plugin before using the ceylon-android plugin')
+    }
+
     extension = project.extensions.create(ANDROID_CEYLON_EXTENSION_NAME, CeylonAndroidExtension, project, instantiator, fileResolver)
 
     androidExtension.sourceSets.all { AndroidSourceSet sourceSet ->
@@ -183,6 +188,11 @@ class CeylonAndroidPlugin implements Plugin<Project> {
         project.plugins.findPlugin('android-library')
 
     return plugin as BasePlugin
+  }
+
+  @CompileStatic
+  static Plugin getCeylonPlugin(Project project) {
+    return project.plugins.findPlugin('com.athaydes.ceylon')
   }
 
   @CompileStatic

--- a/build.gradle
+++ b/build.gradle
@@ -26,8 +26,8 @@ buildscript {
     classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.4'
     classpath 'org.jfrog.buildinfo:build-info-extractor-gradle:4.0.0'
     classpath 'com.android.tools.build:gradle:1.5.0'
-    classpath 'com.redhat.ceylon.gradle:android:0.0.1-SNAPSHOT'
-//    classpath "com.athaydes.gradle.ceylon:ceylon-gradle-plugin:1.1"
+//    classpath 'com.redhat.ceylon.gradle:android:0.0.1-SNAPSHOT'
+    classpath "com.athaydes.gradle.ceylon:ceylon-gradle-plugin:1.1.2"
     classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:0.4.3'
   }
 }


### PR DESCRIPTION
It turns out using the plugin Renato wrote is enough to report errors in Android Studio, and as a bonus it allows us to reuse its configuration and provides an easier way to call `ceylon`.

![image](https://cloud.githubusercontent.com/assets/281528/14380465/d592f862-fd7f-11e5-8655-a77690d7c1da.png)
